### PR TITLE
Feat: Add data models for Rejected NSSAI support

### DIFF
--- a/models/model_reject_cause.go
+++ b/models/model_reject_cause.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * NSSF NS Selection
+ *
+ * Models manually added to support Rejected NSSAI (Strictly based on TS 24.501 Table 9.11.3.46.1)
+ */
+package models
+
+type RejectCause string
+
+const (
+	// Maps to Cause Value 0 (0000)
+	RejectCause_S_NSSAI_NOT_AVAILABLE_IN_CURRENT_PLMN_OR_SNPN RejectCause = "S_NSSAI_NOT_AVAILABLE_IN_CURRENT_PLMN_OR_SNPN"
+
+	// Maps to Cause Value 1 (0001)
+	RejectCause_S_NSSAI_NOT_AVAILABLE_IN_TA RejectCause = "S_NSSAI_NOT_AVAILABLE_IN_TA"
+
+	// Maps to Cause Value 2 (0010)
+	RejectCause_S_NSSAI_NOT_AVAILABLE_DUE_TO_FAILED_OR_REVOKED_NSAA RejectCause = "S_NSSAI_NOT_AVAILABLE_DUE_TO_FAILED_OR_REVOKED_NSAA"
+)

--- a/models/model_rejected_snssai.go
+++ b/models/model_rejected_snssai.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * NSSF NS Selection
+ *
+ * Models manually added to support Rejected NSSAI (based on TS 29.531/29.571)
+ *
+ */
+package models
+
+type RejectedSnssai struct {
+	RejectedSnssai *Snssai     `json:"snssai"`
+	RejectCause    RejectCause `json:"rejectCause,omitempty"`
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind new feature

**What this PR does / why we need it**:
This PR introduces two new model files required to support the Rejected NSSAI feature in the AMF:

1. model_rejected_snssai.go: Defines the RejectedSnssai structure, which wraps an S-NSSAI with a rejection cause.

2. model_reject_cause.go: Defines the RejectCause string constants.

The AMF logic is being updated to validate requested slices against the user's subscription. When a slice is invalid, the AMF needs these data structures to store the rejection details internally before encoding them into the NAS Registration Accept message.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#7](https://github.com/5GC-DEV/openapi-cdac/issues/7)

**Test Report Added?**:
> /kind TESTED


**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
NA

**Special notes for your reviewer**:
NIL
